### PR TITLE
Added missing const declaration to getShape

### DIFF
--- a/src/api/get-shape.js
+++ b/src/api/get-shape.js
@@ -1,6 +1,7 @@
 import { get } from 'axios';
 
-export default getShape = async url => {
+const getShape = async url => {
   const res = await get(url);
   return res;
 };
+export default getShape;


### PR DESCRIPTION
Just add a missing 'const' keyword in the getShape function in get-shape.js